### PR TITLE
fix board constructor back rank pieces

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(ChessNGin
         VERSION 0.1
         LANGUAGES C CXX)
 
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 
 if(CMAKE_BUILD_TYPE MATCHES Debug)
     enable_testing()

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -1,21 +1,48 @@
 #include "board.hpp"
 
+
+auto make_type_ptr(int i, char col, char file, char rank) -> std::unique_ptr<Piece>{
+    switch(i){
+    case 0:
+        return std::make_unique<Rook>(col, Square{file, rank});
+    case 1:
+        return std::make_unique<Knight>(col, Square{file, rank});
+    case 2:
+        return std::make_unique<Bishop>(col, Square{file, rank});
+    case 3:
+        return std::make_unique<Queen>(col, Square{file, rank});
+    case 4:
+        return std::make_unique<King>(col, Square{file, rank});
+    case 5:
+        return std::make_unique<Bishop>(col, Square{file, rank});
+    case 6:
+        return std::make_unique<Knight>(col, Square{file, rank});
+    case 7:
+        return std::make_unique<Rook>(col, Square{file, rank});
+    default:
+        std::cout << "Error, not a piece, exiting.";
+        exit(1);
+    }
+}
+
 Board::Board(){
     m_turn = 'w';
     // FEN - position, turn, castling rights, halfmove counter (for 50 move rule), fullmove counter
     m_current_fen = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
 
-    const std::vector<std::pair<char, char>> starting_square{{'R', 'a'}, {'N', 'b'}, {'B', 'c'}, {'Q', 'd'}, {'K', 'e'}, {'B', 'f'}, {'N', 'g'}, {'R', 'h'}};
+    const std::vector<char> back_rank{'R', 'N', 'B', 'K', 'Q', 'B', 'N', 'R'};
     m_pieces.reserve(32);
 
-    for (auto i: starting_square){ {
-        m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{i.second, '2'}));
-        m_pieces.emplace_back(std::make_unique<Rook>('w', Square{i.second, '1'}));
-        m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{i.second, '7'}));
-        m_pieces.emplace_back(std::make_unique<Rook>('b', Square{i.second, '8'}));
+    for (int i=0; i<back_rank.size(); i++){ {
+        char file = 'a' + i;
+        m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{file, '2'}));
+        m_pieces.emplace_back(make_type_ptr(i, 'w', file, '1'));
+        m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{file, '7'}));
+        m_pieces.emplace_back(make_type_ptr(i, 'b', file, '8'));
         }
     }
 }
+
 
 Board::Board(int variant){
     m_turn = 'w';
@@ -93,7 +120,8 @@ auto Board::print_position() -> void {
 }
 
 auto Board::print() -> void {
-    std::array<char, 64> board_position{};
+    std::vector<char> board_position;
+    board_position.resize(64);
     std::fill(board_position.begin(), board_position.end(), '-');
 
     for (auto &piece: m_pieces){
@@ -102,6 +130,9 @@ auto Board::print() -> void {
         // when printing we start at the top left of the board (a8), so rank=7 (0 index for the array)
         // and file=0 (0 indexed for the array)
         board_position.at(64 - rank*8 + file-8) = piece->get_type();
+        if (piece->get_colour() == 'b'){
+            board_position.at(64 - rank*8 + file-8) += 32;  // convert to lowercase
+        }
     }
 
     for (int i=0; i<64; i++){

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -10,9 +10,9 @@ Board::Board(){
 
     for (auto i: starting_square){ {
         m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{i.second, '2'}));
-        m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{i.second, '1'}));
+        m_pieces.emplace_back(std::make_unique<Rook>('w', Square{i.second, '1'}));
         m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{i.second, '7'}));
-        m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{i.second, '8'}));
+        m_pieces.emplace_back(std::make_unique<Rook>('b', Square{i.second, '8'}));
         }
     }
 }
@@ -115,7 +115,10 @@ auto Board::print() -> void {
 auto Board::is_legal_move(std::string notation) -> bool {
     std::vector<std::string> legal_moves;
     for (auto& piece: m_pieces){
-        legal_moves.emplace_back(piece->generate_legal_moves(this));
+        auto temp_moves = piece->generate_legal_moves(*this);
+        for (auto move: temp_moves){
+            legal_moves.emplace_back(move);
+        }
     }
     // TODO: check if two pieces can move to the same square
     // eg. R on d1 and R on d8 can both move to d5, so the moves must be

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -33,13 +33,12 @@ Board::Board(){
     const std::vector<char> back_rank{'R', 'N', 'B', 'K', 'Q', 'B', 'N', 'R'};
     m_pieces.reserve(32);
 
-    for (int i=0; i<back_rank.size(); i++){ {
-        char file = 'a' + i;
+    for (std::size_t i=0; i<back_rank.size(); i++){
+        char file = char('a' + i);
         m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{file, '2'}));
         m_pieces.emplace_back(make_type_ptr(i, 'w', file, '1'));
         m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{file, '7'}));
         m_pieces.emplace_back(make_type_ptr(i, 'b', file, '8'));
-        }
     }
 }
 
@@ -56,16 +55,19 @@ Board::Board(int variant){
         // Black will mirror White's randomised pieces
         // King must be between the two rooks so that castling both sides is valid
         // otherwise, randomise the backrank
+        m_turn = 'w';
+        // FEN - position, turn, castling rights, halfmove counter (for 50 move rule), fullmove counter
 
-        const std::vector<std::pair<char, char>> starting_square{{'R', 'a'}, {'N', 'b'}, {'B', 'c'}, {'Q', 'd'}, {'K', 'e'}, {'B', 'f'}, {'N', 'g'}, {'R', 'h'}};
+        std::vector<char> back_rank{'R', 'N', 'B', 'K', 'Q', 'B', 'N', 'R'};
+        std::shuffle(back_rank.begin(), back_rank.end(), std::random_device());
         m_pieces.reserve(32);
 
-        for (auto i: starting_square){ {
-            m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{i.second, '2'}));
-            m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{i.second, '1'}));
-            m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{i.second, '7'}));
-            m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{i.second, '8'}));
-            }
+        for (std::size_t i=0; i<back_rank.size(); i++){
+            char file = char('a' + i);
+            m_pieces.emplace_back(std::make_unique<Pawn>('w', Square{file, '2'}));
+            m_pieces.emplace_back(make_type_ptr(i, 'w', file, '1'));
+            m_pieces.emplace_back(std::make_unique<Pawn>('b', Square{file, '7'}));
+            m_pieces.emplace_back(make_type_ptr(i, 'b', file, '8'));
         }
     }
 }
@@ -75,21 +77,18 @@ auto Board::get_fen() -> std::string {
     return m_current_fen;
 }
 
-auto Board::set_fen(std::string& fen_string) -> bool {
+auto Board::set_fen(const std::string& fen_string) -> bool {
     if (check_fen_is_valid(fen_string)){
         m_current_fen = fen_string;
         return true;
     }
-    else{
-        std::cout << "FEN is not valid.\n";
-        return false;
-    }
+    std::cout << "FEN is not valid.\n";
+    return false;
 }
 
-auto Board::check_fen_is_valid(std::string fen) -> bool {
+auto Board::check_fen_is_valid(const std::string& fen) -> bool {
     // check the formatting is correct
-
-    return true;
+    return fen == "todo";
 }
 
 auto Board::print_fen() -> void {
@@ -129,9 +128,10 @@ auto Board::print() -> void {
         auto rank = piece->get_rank();
         // when printing we start at the top left of the board (a8), so rank=7 (0 index for the array)
         // and file=0 (0 indexed for the array)
-        board_position.at(64 - rank*8 + file-8) = piece->get_type();
+        int current_square = 64 - rank*8 + file-8;
+        board_position.at(current_square) = piece->get_type();
         if (piece->get_colour() == 'b'){
-            board_position.at(64 - rank*8 + file-8) += 32;  // convert to lowercase
+            board_position.at(current_square) += 32;  // convert to lowercase
         }
     }
 
@@ -143,7 +143,7 @@ auto Board::print() -> void {
     }
 }
 
-auto Board::is_legal_move(std::string notation) -> bool {
+auto Board::is_legal_move(const std::string& notation) -> bool {
     std::vector<std::string> legal_moves;
     for (auto& piece: m_pieces){
         auto temp_moves = piece->generate_legal_moves(*this);
@@ -158,7 +158,7 @@ auto Board::is_legal_move(std::string notation) -> bool {
     return true;
 }
 
-auto Board::move(std::string notation) -> bool {
+auto Board::move(const std::string& notation) -> bool {
 
     if (is_legal_move(notation)){
         parse_move(notation);
@@ -167,7 +167,7 @@ auto Board::move(std::string notation) -> bool {
     return false;
 }
 
-auto Board::parse_move(std::string move) -> void {
+auto Board::parse_move(const std::string& move) -> void {
     //Square src;
     Square dst;
     int pad{};

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -113,6 +113,14 @@ auto Board::print() -> void {
 }
 
 auto Board::is_legal_move(std::string notation) -> bool {
+    std::vector<std::string> legal_moves;
+    for (auto& piece: m_pieces){
+        legal_moves.emplace_back(piece->generate_legal_moves(this));
+    }
+    // TODO: check if two pieces can move to the same square
+    // eg. R on d1 and R on d8 can both move to d5, so the moves must be
+    // denoted as R1d5 and R8d5 respectively
+
     return true;
 }
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -3,6 +3,7 @@
 
 #include <iostream>
 #include <algorithm>
+#include <random>
 #include <memory>
 
 #include "piece.hpp"
@@ -20,14 +21,14 @@ public:
     Board();
     Board(int variant);
     auto get_fen() -> std::string;
-    auto set_fen(std::string& fen_string) -> bool;
-    auto check_fen_is_valid(std::string fen) -> bool;
+    auto set_fen(const std::string& fen_string) -> bool;
+    auto static check_fen_is_valid(const std::string& fen) -> bool;
     auto print() -> void;
     auto print_fen() -> void;
     auto print_position() -> void;
-    auto is_legal_move(std::string notation) -> bool;
-    auto move(std::string notation) -> bool;
-    auto parse_move(std::string move) -> void;
+    auto is_legal_move(const std::string& notation) -> bool;
+    auto move(const std::string& notation) -> bool;
+    auto parse_move(const std::string& move) -> void;
     auto get_pieces() -> std::vector<std::unique_ptr<Piece>>&;
 };
 

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -5,8 +5,10 @@
 #include <algorithm>
 #include <memory>
 #include <array>
+
 #include "piece.hpp"
 
+class Piece;
 
 class Board {
 private:

--- a/src/board.hpp
+++ b/src/board.hpp
@@ -4,7 +4,6 @@
 #include <iostream>
 #include <algorithm>
 #include <memory>
-#include <array>
 
 #include "piece.hpp"
 

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -1,59 +1,104 @@
 #include "piece.hpp"
 
+Square::Square(char file, char rank) : file{file}, rank{rank} {}
+
+Square::Square(std::string position) {
+    file = position[0];
+    rank = position[1];
+}
+
+auto Square::operator==(Square& other) -> bool{
+    if (file == other.file && rank == other.rank)
+        return true;
+    return false;
+}
+
+auto Square::mirror() -> void {
+    switch(rank){
+    case '1':
+        rank = '8';
+        break;
+    case '2':
+        rank = '7';
+        break;
+    case '3':
+        rank = '6';
+        break;
+    case '4':
+        rank = '5';
+        break;
+    case '5':
+        rank = '4';
+        break;
+    case '6':
+        rank = '3';
+        break;
+    case '7':
+        rank = '2';
+        break;
+    case '8':
+        rank = '1';
+        break;
+    }
+}
+
 Piece::Piece(char type, char colour, Square position) : m_type(type), m_colour(colour), m_position(position) {
     m_legal_moves = {};
 }
 
-auto Piece::get_type() -> char {
+auto Piece::get_type() const -> char {
     return m_type;
 }
 
-auto Piece::get_colour() -> char {
+auto Piece::get_colour() const -> char {
     return m_colour;
+}
+
+auto Piece::get_file() const -> int {
+    return int(m_position.file - 'a');
+}
+
+auto Piece::get_rank() const -> int {
+    return int(m_position.rank - '1');
+}
+
+auto Piece::get_square() const -> Square {
+    return m_position;
 }
 
 auto Piece::move(Square dest) -> void {
         m_position = dest;
 }
 
-auto Piece::get_file() -> int {
-    return int(m_position.file - 'a');
-}
-
-auto Piece::get_rank() -> int {
-    return int(m_position.rank - '1');
-}
-
 Pawn::Pawn(char colour, Square position): Piece('P', colour, position){}
-auto Pawn::promote_pawn(char type) -> void {
 
-}
-auto Pawn::generate_legal_moves() -> std::vector<std::string> {
+auto Pawn::generate_legal_moves(Board* board) -> std::vector<std::string> {
+
     return {" "};
 }
 
 
 Rook::Rook(char colour, Square position): Piece('R', colour, position){}
-auto Rook::generate_legal_moves() -> std::vector<std::string> {
+auto Rook::generate_legal_moves(Board* board) -> std::vector<std::string> {
     return {" "};
 }
 
 Knight::Knight(char colour, Square position): Piece('N', colour, position){}
-auto Knight::generate_legal_moves() -> std::vector<std::string> {
+auto Knight::generate_legal_moves(Board* board) -> std::vector<std::string> {
     return {" "};
 }
 
 Bishop::Bishop(char colour, Square position): Piece('B', colour, position){}
-auto Bishop::generate_legal_moves() -> std::vector<std::string> {
+auto Bishop::generate_legal_moves(Board* board) -> std::vector<std::string> {
     return {" "};
 }
 
 Queen::Queen(char colour, Square position): Piece('Q', colour, position){}
-auto Queen::generate_legal_moves() -> std::vector<std::string> {
+auto Queen::generate_legal_moves(Board* board) -> std::vector<std::string> {
     return {" "};
 }
 
 King::King(char colour, Square position): Piece('K', colour, position){}
-auto King::generate_legal_moves() -> std::vector<std::string> {
+auto King::generate_legal_moves(Board* board) -> std::vector<std::string> {
     return {" "};
 }

--- a/src/piece.cpp
+++ b/src/piece.cpp
@@ -1,5 +1,6 @@
 #include "piece.hpp"
 
+Square::Square() : file{'0'}, rank{'0'} {}
 Square::Square(char file, char rank) : file{file}, rank{rank} {}
 
 Square::Square(std::string position) {
@@ -7,10 +8,8 @@ Square::Square(std::string position) {
     rank = position[1];
 }
 
-auto Square::operator==(Square& other) -> bool{
-    if (file == other.file && rank == other.rank)
-        return true;
-    return false;
+auto Square::operator==(const Square& other) const -> bool {
+    return (file == other.file && rank == other.rank);
 }
 
 auto Square::mirror() -> void {
@@ -72,33 +71,33 @@ auto Piece::move(Square dest) -> void {
 
 Pawn::Pawn(char colour, Square position): Piece('P', colour, position){}
 
-auto Pawn::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto Pawn::generate_legal_moves(Board& board) -> std::vector<std::string> {
 
     return {" "};
 }
 
 
 Rook::Rook(char colour, Square position): Piece('R', colour, position){}
-auto Rook::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto Rook::generate_legal_moves(Board& board) -> std::vector<std::string> {
     return {" "};
 }
 
 Knight::Knight(char colour, Square position): Piece('N', colour, position){}
-auto Knight::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto Knight::generate_legal_moves(Board& board) -> std::vector<std::string> {
     return {" "};
 }
 
 Bishop::Bishop(char colour, Square position): Piece('B', colour, position){}
-auto Bishop::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto Bishop::generate_legal_moves(Board& board) -> std::vector<std::string> {
     return {" "};
 }
 
 Queen::Queen(char colour, Square position): Piece('Q', colour, position){}
-auto Queen::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto Queen::generate_legal_moves(Board& board) -> std::vector<std::string> {
     return {" "};
 }
 
 King::King(char colour, Square position): Piece('K', colour, position){}
-auto King::generate_legal_moves(Board* board) -> std::vector<std::string> {
+auto King::generate_legal_moves(Board& board) -> std::vector<std::string> {
     return {" "};
 }

--- a/src/piece.hpp
+++ b/src/piece.hpp
@@ -6,6 +6,8 @@
 
 #include "board.hpp"
 
+class Board;
+
 // Struct for the squares of the board
 // Parameters:
 // `file` - horizontal column index as a character
@@ -13,9 +15,17 @@
 struct Square {
     char file{};  // a b c d e f g h
     char rank{};  // 1 2 3 4 5 6 7 8
+    Square();
     Square(char file, char rank);
     Square(std::string position);
-    auto operator==(Square& other) -> bool;
+    struct HashFunction{
+        auto operator()(const Square& position) const -> int {
+            int rowHash = std::hash<char>()(position.file);
+            int colHash = std::hash<char>()(position.rank) << 1;
+            return rowHash ^ colHash;
+        }
+    };
+    auto operator==(const Square& other) const -> bool;
     auto mirror() -> void;
 };
 
@@ -36,45 +46,45 @@ public:
     auto get_rank() const -> int;
     auto get_square() const -> Square;
     auto move(Square dest) -> void;
-    auto virtual generate_legal_moves(Board* board) -> std::vector<std::string> = 0;
+    auto virtual generate_legal_moves(Board& board) -> std::vector<std::string> = 0;
 };
 
 
 class Pawn: public Piece {
 public:
     Pawn(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 
 class Rook: public Piece {
 public:
     Rook(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 class Knight: public Piece {
 public:
     Knight(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 class Bishop: public Piece {
 public:
     Bishop(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 class Queen: public Piece {
 public:
     Queen(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 class King: public Piece {
 public:
     King(char colour, Square position);
-    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
+    auto generate_legal_moves(Board& board) -> std::vector<std::string> override;
 };
 
 #endif

--- a/src/piece.hpp
+++ b/src/piece.hpp
@@ -4,11 +4,24 @@
 #include <string>
 #include <vector>
 
+#include "board.hpp"
+
+// Struct for the squares of the board
+// Parameters:
+// `file` - horizontal column index as a character
+// `rank` - vertical row index
 struct Square {
     char file{};  // a b c d e f g h
     char rank{};  // 1 2 3 4 5 6 7 8
+    Square(char file, char rank);
+    Square(std::string position);
+    auto operator==(Square& other) -> bool;
+    auto mirror() -> void;
 };
 
+// Base class for the pieces. Each piece derives from this class and implements its own `generate_legal_moves`
+// Pieces are initialised and contained within the Board constructor as it takes ownership. Use the constructor
+// for the specific piece you need eg `std::make_unique<Pawn>('w', Square{'a', '2'})`
 class Piece {
 private:
     char m_type;
@@ -17,52 +30,51 @@ private:
     std::vector<std::string> m_legal_moves;
 public:
     Piece(char type, char colour, Square position);
-    auto get_type() -> char;
-    auto get_colour() -> char;
-    auto get_file() -> int;
-    auto get_rank() -> int;
+    auto get_type() const -> char;
+    auto get_colour() const -> char;
+    auto get_file() const -> int;
+    auto get_rank() const -> int;
+    auto get_square() const -> Square;
     auto move(Square dest) -> void;
-    auto virtual generate_legal_moves() -> std::vector<std::string> = 0;
+    auto virtual generate_legal_moves(Board* board) -> std::vector<std::string> = 0;
 };
 
 
 class Pawn: public Piece {
 public:
     Pawn(char colour, Square position);
-    auto promote_pawn(char type) -> void;
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
 
 
 class Rook: public Piece {
 public:
     Rook(char colour, Square position);
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
 
 class Knight: public Piece {
 public:
     Knight(char colour, Square position);
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
 
 class Bishop: public Piece {
 public:
     Bishop(char colour, Square position);
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
 
 class Queen: public Piece {
 public:
     Queen(char colour, Square position);
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
 
 class King: public Piece {
 public:
     King(char colour, Square position);
-    auto generate_legal_moves() -> std::vector<std::string> override;
+    auto generate_legal_moves(Board* board) -> std::vector<std::string> override;
 };
-
 
 #endif

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -1,6 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <sstream>
-#include <set>
+#include <unordered_set>
 
 #include "board.hpp"
 #include "piece.hpp"
@@ -28,11 +28,10 @@
  *
 */
 
-
 TEST_CASE("Board constructor sets up pieces correctly", "[board]"){
     Board chessboard{};
     auto& piece_vector = chessboard.get_pieces();
-    std::set<Square> occupied{};
+    std::unordered_set<Square, Square::HashFunction> occupied;
     int num_white{};
     int num_black{};
 
@@ -41,7 +40,7 @@ TEST_CASE("Board constructor sets up pieces correctly", "[board]"){
         auto colour = piece->get_colour();
         auto position = piece->get_square();
 
-        REQUIRE(occupied.find(position) == occupied.end());
+        REQUIRE(occupied.contains(position) == false);
         occupied.insert(position);
         // By doing this mirror, we automatically check that black pieces are on the 7th and 8th ranks
         // as the mirrors must be on the 1st and 2nd ranks to pass the checks below, just as with the white pieces.
@@ -61,15 +60,15 @@ TEST_CASE("Board constructor sets up pieces correctly", "[board]"){
             break;
         case 'R':
             REQUIRE(position.rank == '1');
-            REQUIRE(position.file == 'a' || position.file == 'h');
+            REQUIRE((position.file == 'a' || position.file == 'h'));
             break;
         case 'N':
             REQUIRE(position.rank == '1');
-            REQUIRE(position.file == 'b' || position.file == 'g');
+            REQUIRE((position.file == 'b' || position.file == 'g'));
             break;
         case 'B':
             REQUIRE(position.rank == '1');
-            REQUIRE(position.file == 'c' || position.file == 'f');
+            REQUIRE((position.file == 'c' || position.file == 'f'));
             break;
         case 'Q':
             REQUIRE(position.rank == '1');
@@ -92,8 +91,8 @@ TEST_CASE("Board print", "[board]"){
     auto old_buf = std::cout.rdbuf(ss.rdbuf());
 
     chessboard.print();
-    std::string expected_output{"rnbqkbnr\nPPPPPPPP\n--------\n--------\n--------\n--------\nPPPPPPPP\nRNBQKBNR\n"};
-    REQUIRE(expected_output.compare(ss.str()) == 0);
+    std::string expected_output{"rnbqkbnr\npppppppp\n--------\n--------\n--------\n--------\nPPPPPPPP\nRNBQKBNR\n"};
+    REQUIRE(expected_output == ss.str());
 
     std::cout.rdbuf(old_buf); //reset
 }

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -84,6 +84,7 @@ TEST_CASE("Board constructor sets up pieces correctly", "[board]"){
     REQUIRE(num_black == 16);
 }
 
+
 TEST_CASE("Board print", "[board]"){
     Board chessboard{};
     std::stringstream ss;
@@ -91,11 +92,12 @@ TEST_CASE("Board print", "[board]"){
     auto old_buf = std::cout.rdbuf(ss.rdbuf());
 
     chessboard.print();
+    std::cout.rdbuf(old_buf); //reset now, causes a segfault if done after the require assertion
     std::string expected_output{"rnbqkbnr\npppppppp\n--------\n--------\n--------\n--------\nPPPPPPPP\nRNBQKBNR\n"};
-    REQUIRE(expected_output == ss.str());
 
-    std::cout.rdbuf(old_buf); //reset
+    REQUIRE(expected_output == ss.str());
 }
+
 
 TEST_CASE("Board move", "[board, piece]"){
     Board chessboard{};


### PR DESCRIPTION
What does this PR do?

Board constructor now returns the correct setup.
This code is definitely open to being improved upon as it seems rather hacky atm

Also fix segfault happening in the testing of the board print method due to the cout buffer not being reset 

<!--
Please include a summary of the change and which issue is fixed.
Please also include relevant motivation and context.
List any dependencies that are required for this change.
-->

Related to  #15
Closes #4

<!--
Fixes #23445
Closes #23445
 -->

<!-- Does your PR introduce any breaking changes? If yes, please list them. -->

<details>
  <summary><b>Before submitting</b></summary>

- [x] Was this **discussed** via a GitHub issue? (not for typos and docs)
- [x] Did you read the [contributor guideline](https://github.com/ryan597/chessengine/.github/CONTRIBUTING.md), **Pull Request** section?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [x] Did you write any **new necessary tests**? (not for typos and docs)
- [x] Did you verify new and **existing tests pass** locally with your changes?
- [x] Did you list all the **breaking changes** introduced by this pull request?

<!-- In the CHANGELOG, separate each item in the unreleased section by a blank line to reduce collisions -->

</details>

## PR review

<details>
  <summary>Reviewer checklist</summary>

- [ ] Is this pull request ready for review? (if not, please submit in draft mode)
- [ ] Check that all items from **Before submitting** are resolved
- [ ] Make sure the title is self-explanatory and the description concisely explains the PR
- [ ] Add labels and milestones (and optionally projects) to the PR so it can be classified

</details>
